### PR TITLE
DeviceParts:  Fixed Spectrum Tile Derp

### DIFF
--- a/src/com/rebellion/deviceparts/SpectrumTileService.java
+++ b/src/com/rebellion/deviceparts/SpectrumTileService.java
@@ -22,7 +22,7 @@ public class SpectrumTileService extends TileService {
             int currentState = FileUtils.getintProp(DeviceSettings.SPECTRUM_SYSTEM_PROPERTY, 0);
 
             int nextState;
-            if (currentState == 4) {
+            if (currentState == 3) {
             nextState = 0;
         } else {
             nextState = currentState + 1;


### PR DESCRIPTION
Its Helps To Avoid Crash ,
We Had Only 4 modes and 5 cases Were Addressed
And It Was Crashing In The 5th Case (ie after gaming mode)

Signed-off-by: HeartStealer786 <beingme639@gmail.com>